### PR TITLE
Feature: Switch RTOS timer to Virtual timer

### DIFF
--- a/FreeRTOS/Demo/CORTEX_A55_SOCFPGA/startup/cpu_init.S
+++ b/FreeRTOS/Demo/CORTEX_A55_SOCFPGA/startup/cpu_init.S
@@ -129,14 +129,6 @@ SwitchToEL1:
 	orr x0, x0,  #(1<<34) // E2H=1 EL2 host enable.
 	msr hcr_el2, x0
 
-	// When HCR_EL2.TGE is 0, EL1PTEN == 1 or EL1PCTEN == 1,
-    // Give access to physical timer and counter registers
-    // from lower Exception levels EL0/1, (Avoid trap to EL2)
-	mrs x1, cnthctl_el2
-	orr x1, x1,  #(1<<10) // EL1PCTEN
-	orr x1, x1,  #(1<<11) // EL1PTEN
-	msr cnthctl_el2, x1
-
 	mov x0, #0b00101      // Use the EL1 stack from EL1.
 	msr spsr_el2, x0      // M[4:0]=00101 EL1h must match HCR_EL2.RW.
 

--- a/FreeRTOS/portable/GCC/ARM_CA55_64_BIT/port.c
+++ b/FreeRTOS/portable/GCC/ARM_CA55_64_BIT/port.c
@@ -118,13 +118,13 @@
     {                                                                                       \
         portDISABLE_INTERRUPTS();                                                           \
         __asm volatile ( "msr ICC_PMR_EL1, %0\n" : : "r" ( portUNMASK_VALUE ) : "memory" ); \
-        __asm volatile ( "DSB SY		\n"                                                 \
-                         "ISB SY		\n");                                                    \
+        __asm volatile ( "DSB SY        \n"                                                 \
+                         "ISB SY        \n");                                               \
         portENABLE_INTERRUPTS();                                                            \
     }
 
 /* Hardware specifics used when sanity checking the configuration. */
-/* #define portINTERRUPT_PRIORITY_REGISTER_OFFSET		0x400UL */
+/* #define portINTERRUPT_PRIORITY_REGISTER_OFFSET       0x400UL */
 #define portINTERRUPT_PRIORITY_REGISTER_OFFSET    0x4UL
 #define portMAX_8_BIT_VALUE                       ( ( uint8_t ) 0xff )
 #define portBIT_0_SET                             ( ( uint8_t ) 0x01 )
@@ -350,7 +350,7 @@ __asm volatile ( "MRS %0, CurrentEL" : "=r" ( ulAPSR ) );
         if( ( ulRawReadICC_BPR1_EL1() & portBINARY_POINT_BITS ) <= portMAX_BINARY_POINT_VALUE )
         {
             /* Interrupts are turned off in the CPU itself to ensure a tick does
-               not execute	while the scheduler is being started.  Interrupts are
+               not execute while the scheduler is being started.  Interrupts are
                automatically turned back on in the CPU when the first task starts
                executing. */
             portDISABLE_INTERRUPTS();
@@ -446,8 +446,8 @@ void FreeRTOS_Tick_Handler( void )
        necessary to turn off interrupts in the CPU itself while the ICCPMR is being
        updated. */
     ulRawWriteICC_PMR_EL1( ( uint32_t ) ( configMAX_API_CALL_INTERRUPT_PRIORITY << portPRIORITY_SHIFT ) );
-    __asm volatile ( "dsb sy		\n"
-                     "isb sy		\n"::: "memory" );
+    __asm volatile ( "dsb sy           \n"
+                     "isb sy           \n"::: "memory" );
 
     /* Ok to enable interrupts after the interrupt source has been cleared. */
     configCLEAR_TICK_INTERRUPT();
@@ -501,8 +501,8 @@ uint32_t ulReturn;
     {
         ulReturn = pdFALSE;
         ulRawWriteICC_PMR_EL1( ( uint32_t ) ( configMAX_API_CALL_INTERRUPT_PRIORITY << portPRIORITY_SHIFT ) );
-        __asm volatile ( "dsb sy		\n"
-                         "isb sy		\n"::: "memory" );
+        __asm volatile ( "dsb sy        \n"
+                         "isb sy        \n"::: "memory" );
     }
 
     portENABLE_INTERRUPTS();

--- a/FreeRTOS/portable/GCC/ARM_CA55_64_BIT/portSocfpga.c
+++ b/FreeRTOS/portable/GCC/ARM_CA55_64_BIT/portSocfpga.c
@@ -12,27 +12,39 @@
 
 #include <socfpga_interrupt.h>
 
-#define AGX5_CNTP_CTL_ENABLE            ( 1 << 0 )
+#define AGX5_CNTV_CTL_ENABLE            ( 1 << 0 )
 #define TMR_DELAY_SECS                  ( 1 )
 #define coretimerTIMER_INITIAL_VALUE    0
 /*-----------------------------------------------------------*/
 
 static uint64_t ullCounterFreq = 0;
+static uint64_t ullCounterCurrVal = 0;
+static uint64_t ullCounterReloadVal = 0;
 
 /*-----------------------------------------------------------*/
-static void vPortAgilex5A55SetPhysicalTimerControl( uint32_t uTimerControl )
+static void vPortAgilex5A55SetVirtualTimerControl( uint32_t ulTimerControl )
 {
-    asm volatile ( "MSR CNTP_CTL_EL0, %0" : : "r" ( uTimerControl ) );
+    asm volatile ( "MSR CNTV_CTL_EL0, %0" : : "r" ( ulTimerControl ) );
 }
 /*-----------------------------------------------------------*/
 
-static void vPortAgilex5A55SetPhysicalTimerValue( uint32_t uTimerValue )
+static void vPortAgilex5A55SetVirtualTimerValue( uint32_t ulTimerValue )
 {
-    asm volatile ( "MSR CNTP_TVAL_EL0, %0" : : "r" ( uTimerValue ) );
+    asm volatile ( "MSR CNTV_TVAL_EL0, %0" : : "r" ( ulTimerValue ) );
 }
 /*-----------------------------------------------------------*/
 
-static uint32_t vPortAgilex5A55TGetFrequency()
+static void vPortAgilex5A55SetVirtualTimerCompareValue( void )
+{
+    /* The value of the counter will be equal to or greater than
+     * ullCounterCurrval when this function is called.
+     */
+    ullCounterCurrVal += ullCounterReloadVal;
+    asm volatile ( "MSR CNTV_CVAL_EL0, %0" : : "r" ( ullCounterCurrVal ) );
+}
+/*-----------------------------------------------------------*/
+
+static uint32_t vPortAgilex5A55TGetFrequency( void )
 {
 uint32_t uFreq;
 
@@ -44,34 +56,33 @@ uint32_t uFreq;
 void vPortAgilex5A55TimerIRQHandler( void * data )
 {
     ( void ) data;
-    /* Disable timer to clear interrupt. */
-    vPortAgilex5A55SetPhysicalTimerControl( 0 );
 
-    /* Set timer delay. */
-    vPortAgilex5A55SetPhysicalTimerValue( ( ( TMR_DELAY_SECS ) *ullCounterFreq ) / ( configTICK_RATE_HZ ) );
+    /* Configure when the next interrupt will be triggered. */
+    vPortAgilex5A55SetVirtualTimerCompareValue();
 
     /* Call the Tick handler. */
     FreeRTOS_Tick_Handler();
 
-    /* Enable the timer. */
-    vPortAgilex5A55SetPhysicalTimerControl( AGX5_CNTP_CTL_ENABLE );
 }
 /*-----------------------------------------------------------*/
 
 void vPortAgilex5A55TimerInit( void )
 {
     /*Register the callback*/
-    interrupt_register_isr( EL1PHY_TMR_INTR, vPortAgilex5A55TimerIRQHandler, NULL );
+    interrupt_register_isr( EL1VIRT_TMR_INTR, vPortAgilex5A55TimerIRQHandler, NULL );
 
     /* Configure interrupt. */
-    interrupt_enable( EL1PHY_TMR_INTR, interrupt_min_interrupt_priority );
+    interrupt_enable( EL1VIRT_TMR_INTR, interrupt_min_interrupt_priority );
 
-    /* Set the tickrate. */
-    vPortAgilex5A55SetPhysicalTimerValue( coretimerTIMER_INITIAL_VALUE );
-
-    /*Load initial timer period and kick the timer*/
+    /* Calculate the timer delay */
     ullCounterFreq = vPortAgilex5A55TGetFrequency();
-    vPortAgilex5A55SetPhysicalTimerValue( ( ( TMR_DELAY_SECS ) *ullCounterFreq ) / ( configTICK_RATE_HZ ) );
-    vPortAgilex5A55SetPhysicalTimerControl( AGX5_CNTP_CTL_ENABLE );
+    ullCounterReloadVal = ( TMR_DELAY_SECS * ullCounterFreq ) / configTICK_RATE_HZ;
+
+    /* Get the current value of the timer */
+    __asm__ volatile("mrs %0, CNTVCT_EL0" : "=r"(ullCounterCurrVal));
+
+    /*Set the intial timer delay and enable timer interrupts */
+    vPortAgilex5A55SetVirtualTimerCompareValue();
+    vPortAgilex5A55SetVirtualTimerControl( AGX5_CNTV_CTL_ENABLE );
 }
 /*-----------------------------------------------------------*/

--- a/drivers/gic/socfpga_interrupt.c
+++ b/drivers/gic/socfpga_interrupt.c
@@ -71,8 +71,7 @@ void interrupt_init_gic(void)
     /* Set the interrupt mask. */
     gic_reg_write_group1_end_of_interrupt(0xFF);
 
-    /* Enable interrupt groups. */
-    gic_reg_enable_group0_interrupts();
+    /* Enable group 1 interrupts (group 0 are secure interrupts). */
     gic_reg_enable_group1_interrupts();
 }
 
@@ -232,8 +231,6 @@ void interrupt_irq_handler(unsigned int interrupt_id)
         INFO("FIQ: Panic, unexpected INTID");
     }
 
-    /* Write EOIR to deactivate interrupt. */
-    gic_reg_enable_group0_interrupts();
     gic_enable_interrupts();
 
     return;

--- a/drivers/gic/socfpga_interrupt.h
+++ b/drivers/gic/socfpga_interrupt.h
@@ -63,6 +63,7 @@
 typedef enum {
     /*System PPIs*/
     PPI_START = 22, /*!<Start of Private Peripheral Interface (PPI) interrupts*/
+    EL1VIRT_TMR_INTR = 27, /*!< EL1 Phy Timer Interrupt */
     EL1PHY_TMR_INTR = 30, /*!< EL1 Phy Timer Interrupt */
     PPI_MAX = 30, /*!< Maximum PPI interrupts */
 


### PR DESCRIPTION
Description:
        - Using the physical timer could introduce issues when used
          in systems with multiple guest OSes (managed by a hypervisor),
          As there is only one physical timer instance per core. Use
          virtual timer to resolve this issue.
        - Maintain a continous count without reseting the timer on each
          tick interval.
        - Blocked access of physical timer in EL1.