### PR TITLE
Rename submodule 'freertos' to 'FreeRTOS/Source'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "freertos"]
+[submodule "FreeRTOS/Source"]
 	path = FreeRTOS/Source
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
 [submodule "FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP"]


### PR DESCRIPTION
When the submodules are initialized under Windows this fails with
`fatal: could not get a repository handle for submodule 'FreeRTOS/Source'`

Using the same name as the path for this submodule fixes this.